### PR TITLE
Added docstrings to GradeAnswer to solve ParamValidationError

### DIFF
--- a/graph/chains/answer_grader.py
+++ b/graph/chains/answer_grader.py
@@ -5,7 +5,8 @@ from langchain_openai import ChatOpenAI
 
 
 class GradeAnswer(BaseModel):
-
+    """Binary score to tell whether the answer addresses the question."""
+    
     binary_score: bool = Field(
         description="Answer addresses the question, 'yes' or 'no'"
     )


### PR DESCRIPTION
Without that docstrings, I get:

ParamValidationError: Parameter validation failed:
Invalid length for parameter toolConfig.tools[0].toolSpec.description, value: 0, valid min length: 1

with:
langchain==0.2.16
langchain-community==0.2.16
langchain-core==0.2.38
langchain-openai==0.1.23
langchain-text-splitters==0.2.4
langgraph==0.2.18
langgraph-checkpoint==1.0.9
langsmith==0.1.111