### PR TITLE
Migrate RAG prompt loading to LangSmith Client

### DIFF
--- a/graph/chains/generation.py
+++ b/graph/chains/generation.py
@@ -1,8 +1,10 @@
-from langchain import hub
 from langchain_core.output_parsers import StrOutputParser
 from langchain_openai import ChatOpenAI
+from langsmith import Client
+
+client = Client()
 
 llm = ChatOpenAI(temperature=0)
-prompt = hub.pull("rlm/rag-prompt")
+prompt = client.pull_prompt("rlm/rag-prompt")
 
 generation_chain = prompt | llm | StrOutputParser()


### PR DESCRIPTION
This PR updates the prompt loading mechanism to use the latest LangSmith Client API
instead of `langchain.hub`.

- Replaced `hub.pull("rlm/rag-prompt")` with `client.pull_prompt("rlm/rag-prompt")`
- Added LangSmith Client initialization
- Kept the generation chain behavior unchanged