### PR TITLE
Update Udemy coupon code to JAN-2026

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 
 ![Logo](https://github.com/emarco177/langgraph-course/blob/main/banner.png)
 
-[![Udemy](https://img.shields.io/badge/Udemy-Course-EC5252?style=for-the-badge&logo=udemy&logoColor=white)](https://www.udemy.com/course/langgraph/?couponCode=OCT-2025) 
+[![Udemy](https://img.shields.io/badge/Udemy-Course-EC5252?style=for-the-badge&logo=udemy&logoColor=white)](https://www.udemy.com/course/langgraph/?couponCode=JAN-2026) 
 [![Rating](https://img.shields.io/badge/Rating-4.7/5-brightgreen?style=for-the-badge)](https://www.udemy.com/course/langgraph/) 
-[![Students](https://img.shields.io/badge/Students-13K+-blue?style=for-the-badge)](https://www.udemy.com/course/langgraph/?couponCode=DEC-2025)
+[![Students](https://img.shields.io/badge/Students-13K+-blue?style=for-the-badge)](https://www.udemy.com/course/langgraph/?couponCode=JAN-2026)
 [![Twitter](https://img.shields.io/twitter/follow/EdenEmarco177?label=Follow&style=social)](https://twitter.com/EdenEmarco177)
 
 > **Build production-grade AI agents—fast.** This repository is the hands-on companion to my Udemy bestseller. Every branch is a *project*, every commit is a *lesson*. Clone it, code along, and ship your own LangGraph agents.


### PR DESCRIPTION
Changed coupon codes in README badges from OCT-2025 and DEC-2025 to JAN-2026.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates promotional links in `README.md`.
> 
> - Changes Udemy and Students badge URLs to use `couponCode=JAN-2026` (replacing `OCT-2025`/`DEC-2025`)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a832e71d6e8198751ee1d2b9e590b54b817ff002. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->